### PR TITLE
perf: optimize hero/LCP, cut homepage JS, move API fetching to server components

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -13,14 +13,15 @@ export const metadata: Metadata = {
 };
 
 interface BlogPageProps {
-  searchParams?: {
+  searchParams?: Promise<{
     page?: string;
-  };
+  }>;
 }
 
-export default function BlogPage({ searchParams }: BlogPageProps) {
+export default async function BlogPage({ searchParams }: BlogPageProps) {
 
-  const currentPage = Number(searchParams?.page) || 1;
+  const params = await searchParams;
+  const currentPage = Number(params?.page) || 1;
 
   return (
     <main>

--- a/src/app/category/[...slug]/page.tsx
+++ b/src/app/category/[...slug]/page.tsx
@@ -4,8 +4,8 @@ import { Suspense } from "react";
 import CategoryPage from "@/components/category/category-page";
 import PageHeader from "@/components/common/header";
 import ProductsLoading from "@/components/shop/products-loading";
-import { getCategories } from "@/lib/api";
-import { Category } from "@/lib/interfaces";
+import { getCategories, getProducts } from "@/lib/api";
+import { Category, Product } from "@/lib/interfaces";
 
 type Props = {
   params: Promise<{ slug: string[] }>;
@@ -19,20 +19,35 @@ export default async function CategoryPageRoute({ params }: Props) {
   }
 
   const categorySlug = slug[0];
-  const categories: Category[] = await getCategories();
-  const category = categories.find(
-    (c) => c.slug.toLowerCase().trim() === categorySlug.toLowerCase().trim()
+  const normalizedSlug = categorySlug.toLowerCase().trim();
+
+  // Fetch on the cached server and pass to the client filter UI as props.
+  const [categories, allProducts] = await Promise.all([
+    getCategories(),
+    getProducts(),
+  ]);
+
+  const category = (categories as Category[]).find(
+    (c: Category) => c.slug.toLowerCase().trim() === normalizedSlug
   );
 
   if (!category) {
     notFound();
   }
 
+  const categoryProducts: Product[] = (allProducts || []).filter(
+    (p: Product) => p.category?.slug?.toLowerCase().trim() === normalizedSlug
+  );
+
   return (
     <main>
       <PageHeader />
       <Suspense fallback={<ProductsLoading />}>
-        <CategoryPage slug={categorySlug} />
+        <CategoryPage
+          slug={categorySlug}
+          initialCategory={category}
+          initialProducts={categoryProducts}
+        />
       </Suspense>
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,8 @@ const TestimonialsSection = dynamic(() => import("@/components/home/testinomial-
 const FlooringProjectSection = dynamic(() => import("@/components/home/nationwide-section"));
 const CompanyOverviewSection = dynamic(() => import("@/components/home/overview-section"));
 const CTASection2 = dynamic(() => import("@/components/home/CTA-section2"));
-const BlogList = dynamic(() => import("@/components/blogs/blog-section"));
+// BlogList is a server component (fetches on the server) so it ships no client JS.
+import BlogList from "@/components/blogs/blog-section";
 
 export const metadata = {
   title: "Vinyl Flooring Malaysia | SPC, Laminate & Carpet Tiles | Furnishing",

--- a/src/app/shop/[...slug]/page.tsx
+++ b/src/app/shop/[...slug]/page.tsx
@@ -4,8 +4,8 @@ import type { Metadata } from "next";
 import SingleProduct from "@/components/shop/single-product";
 import PageHeader from "@/components/common/header";
 import ProductLoading from "@/components/shop/product-loading";
-import { getProductBySlug } from "@/lib/api";
-import { getFullImageUrl } from "@/lib/interfaces";
+import { getProductBySlug, getProducts } from "@/lib/api";
+import { getFullImageUrl, Product } from "@/lib/interfaces";
 
 type Params = {
   slug: string[];
@@ -72,15 +72,30 @@ async function ProductContent({
       ...productData.images,
       main_image: getFullImageUrl(productData.images.main_image),
       gallery: (productData.images.gallery || []).map(getFullImageUrl),
-      thumbnails: productData.images.thumbnails 
-        ? (Array.isArray(productData.images.thumbnails) 
+      thumbnails: productData.images.thumbnails
+        ? (Array.isArray(productData.images.thumbnails)
             ? productData.images.thumbnails.map(getFullImageUrl)
             : [])
         : [],
     },
   };
 
-  return <SingleProduct productData={productWithFullUrls} />;
+  // Compute related products on the cached server (same category first,
+  // then fall back to any other products) instead of fetching on the client.
+  const allProducts: Product[] = (await getProducts()) || [];
+  let relatedProducts = allProducts
+    .filter((p) => p.category?.slug === canonicalCategory && p.id !== productData.id)
+    .slice(0, 4);
+  if (relatedProducts.length === 0) {
+    relatedProducts = allProducts.filter((p) => p.id !== productData.id).slice(0, 4);
+  }
+
+  return (
+    <SingleProduct
+      productData={productWithFullUrls}
+      relatedProducts={relatedProducts}
+    />
+  );
 }
 
 export const revalidate = 300;

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import PageHeader from "@/components/common/header";
 import ProductsSection from "@/components/shop/product-section";
 import ProductsLoading from "@/components/shop/products-loading";
+import { getCategories, getProducts } from "@/lib/api";
 
 export const metadata: Metadata = {
     title: "Shop Vinyl, SPC, Laminate & Carpet Tiles Online in Malaysia | Furnishing",
@@ -26,17 +27,25 @@ export default async function Shop({ searchParams }: ShopPageProps) {
     const category = params?.category;
     const sort = params?.sort;
 
+    // Fetch on the server (cached via the centralized API) and pass to the
+    // client filter UI as props — no client-side /api/products request.
+    const [initialProducts, initialCategories] = await Promise.all([
+        getProducts(),
+        getCategories(),
+    ]);
+
     return (
         <main>
             <PageHeader title="Vinyl & Flooring Solutions in Malaysia" />
-            
-            
+
             <Suspense fallback={<ProductsLoading />}>
-                <ProductsSection 
+                <ProductsSection
                     page={page}
                     category={category}
                     sort={sort}
                     itemsPerPage={12}
+                    initialProducts={initialProducts}
+                    initialCategories={initialCategories}
                 />
             </Suspense>
         </main>

--- a/src/components/blog/related-products.tsx
+++ b/src/components/blog/related-products.tsx
@@ -1,6 +1,3 @@
-'use client';
-
-import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { getProducts } from "@/lib/api";
@@ -8,7 +5,7 @@ import { Product, getFullImageUrl } from "@/lib/interfaces";
 
 function shuffleArray<T>(array: T[]): T[] {
     if (!Array.isArray(array)) return [];
-    
+
     const shuffled = [...array];
     for (let i = shuffled.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
@@ -17,52 +14,14 @@ function shuffleArray<T>(array: T[]): T[] {
     return shuffled;
 }
 
-export default function RelatedProducts() {
-    const [products, setProducts] = useState<Product[]>([]);
-    const [loading, setLoading] = useState(true);
-
-    useEffect(() => {
-        const fetchProducts = async () => {
-            try {
-                setLoading(true);
-                
-                const productsData = await getProducts();
-
-                if (Array.isArray(productsData) && productsData.length > 0) {
-                    const shuffledProducts = shuffleArray(productsData);
-                    setProducts(shuffledProducts.slice(0, 4));
-                } else {
-                    setProducts([]);
-                }
-            } catch (error) {
-                console.error('Error fetching products:', error);
-                setProducts([]);
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        fetchProducts();
-    }, []);
-
-    if (loading) {
-        return (
-            <div className="py-12">
-                <div className="container mx-auto px-6">
-                    <h2 className="text-3xl font-bold mb-8 text-center">Products</h2>
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-                        {[...Array(4)].map((_, i) => (
-                            <div key={i} className="animate-pulse">
-                                <div className="bg-gray-200 h-56 rounded-2xl mb-4"></div>
-                                <div className="bg-gray-200 h-6 rounded mb-2"></div>
-                                <div className="bg-gray-200 h-4 rounded w-2/3"></div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            </div>
-        );
-    }
+// Server component: products are fetched on the cached server (no client-side
+// /api/products download). Rendered as static HTML.
+export default async function RelatedProducts() {
+    const productsData = await getProducts();
+    const products: Product[] =
+        Array.isArray(productsData) && productsData.length > 0
+            ? shuffleArray(productsData).slice(0, 4)
+            : [];
 
     if (products.length === 0) {
         return null;

--- a/src/components/blog/single-blog-content.tsx
+++ b/src/components/blog/single-blog-content.tsx
@@ -1,5 +1,5 @@
-'use client';
-
+// Server component: only renders blog content (no client-side state/effects),
+// so it ships no client JS and the related products are fetched on the server.
 import Image from "next/image";
 import PageHeader from "@/components/common/header";
 import RelatedProducts from "@/components/blog/related-products";

--- a/src/components/blogs/blog-section.tsx
+++ b/src/components/blogs/blog-section.tsx
@@ -1,10 +1,8 @@
-'use client';
-
-import { useState, useEffect, Suspense } from 'react';
+// Server component: blogs are fetched on the cached server, so the browser no
+// longer downloads the large /api/blogs payload. Pagination uses normal links
+// (?page=N) which the statically-rendered route serves from cache.
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
-import SquareLoader from '../common/loader';
 import { getBlogs } from '@/lib/api';
 import { Blog, getBlogImageUrl } from '@/lib/interfaces';
 
@@ -16,166 +14,94 @@ interface BlogListProps {
   currentPage?: number;
 }
 
-const BlogListContent = ({
+function getVisiblePages(currentPage: number, totalPages: number): (number | '...')[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  if (currentPage <= 4) {
+    return [1, 2, 3, 4, 5, '...', totalPages];
+  }
+  if (currentPage >= totalPages - 3) {
+    return [1, '...', totalPages - 4, totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
+  }
+  return [1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPages];
+}
+
+function PaginationControls({
+  currentPage,
+  totalPages,
+}: {
+  currentPage: number;
+  totalPages: number;
+}) {
+  if (totalPages <= 1) return null;
+
+  const visiblePages = getVisiblePages(currentPage, totalPages);
+  const baseBtn = 'px-4 py-2 rounded-md transition-colors';
+
+  return (
+    <div className="flex justify-center items-center space-x-2 mt-12">
+      {currentPage === 1 ? (
+        <span className={`${baseBtn} bg-gray-100 text-gray-400 cursor-not-allowed`}>Previous</span>
+      ) : (
+        <Link href={`?page=${currentPage - 1}`} className={`${baseBtn} bg-orange-600 text-white hover:bg-orange-700`}>
+          Previous
+        </Link>
+      )}
+
+      <div className="flex space-x-2">
+        {visiblePages.map((page, index) =>
+          page === '...' ? (
+            <span key={`ellipsis-${index}`} className="w-10 h-10 flex items-center justify-center">
+              ...
+            </span>
+          ) : (
+            <Link
+              key={page}
+              href={`?page=${page}`}
+              className={`w-10 h-10 flex items-center justify-center rounded-md transition-colors ${
+                currentPage === page
+                  ? 'bg-orange-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              {page}
+            </Link>
+          )
+        )}
+      </div>
+
+      {currentPage === totalPages ? (
+        <span className={`${baseBtn} bg-gray-100 text-gray-400 cursor-not-allowed`}>Next</span>
+      ) : (
+        <Link href={`?page=${currentPage + 1}`} className={`${baseBtn} bg-orange-600 text-white hover:bg-orange-700`}>
+          Next
+        </Link>
+      )}
+    </div>
+  );
+}
+
+export default async function BlogList({
   limit,
   showHeader = true,
   showPagination = false,
   itemsPerPage = 9,
-  currentPage: propCurrentPage,
-}: BlogListProps) => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const initialPage = propCurrentPage || Number(searchParams.get('page')) || 1;
-  const [currentPage, setCurrentPage] = useState(initialPage);
-
-  const [blogs, setBlogs] = useState<Blog[]>([]);
-  const [allBlogs, setAllBlogs] = useState<Blog[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const pageFromUrl = propCurrentPage || Number(searchParams.get('page')) || 1;
-    setCurrentPage(pageFromUrl);
-  }, [searchParams, propCurrentPage]);
-
-  useEffect(() => {
-    const fetchBlogs = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-
-        const response = await getBlogs();
-
-        if (response.success && response.data) {
-          const blogsData = response.data;
-          setAllBlogs(blogsData);
-
-          if (!showPagination) {
-            setBlogs(limit ? blogsData.slice(0, limit) : blogsData);
-          }
-        } else {
-          throw new Error('Failed to fetch blogs');
-        }
-      } catch (err) {
-        console.error('Error fetching blogs:', err);
-        setError('Failed to load blogs. Please try again.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchBlogs();
-  }, [limit, showPagination]);
+  currentPage = 1,
+}: BlogListProps) {
+  const response = await getBlogs();
+  const allBlogs: Blog[] = response.success && Array.isArray(response.data) ? response.data : [];
 
   const totalBlogs = allBlogs.length;
   const totalPages = Math.ceil(totalBlogs / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
-  const paginatedBlogs = allBlogs.slice(startIndex, startIndex + itemsPerPage);
-  const displayBlogs = showPagination ? paginatedBlogs : blogs;
 
-    const handlePageChange = (page: number) => {
-    if (page < 1 || page > totalPages) return; // prevent invalid pages
-    setCurrentPage(page);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-    };
-
-
-  const PaginationControls = () => {
-    if (totalPages <= 1) return null;
-
-    const getVisiblePages = () => {
-      if (totalPages <= 7) {
-        return Array.from({ length: totalPages }, (_, i) => i + 1);
-      }
-
-      if (currentPage <= 4) {
-        return [1, 2, 3, 4, 5, '...', totalPages];
-      }
-
-      if (currentPage >= totalPages - 3) {
-        return [1, '...', totalPages - 4, totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
-      }
-
-      return [1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPages];
-    };
-
-    const visiblePages = getVisiblePages();
-
-    return (
-      <div className="flex justify-center items-center space-x-2 mt-12">
-        <button
-          onClick={() => handlePageChange(currentPage - 1)}
-          disabled={currentPage === 1}
-          className={`px-4 py-2 rounded-md transition-colors ${
-            currentPage === 1
-              ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-              : 'bg-orange-600 text-white hover:bg-orange-700'
-          }`}
-        >
-          Previous
-        </button>
-
-        <div className="flex space-x-2">
-          {visiblePages.map((page, index) =>
-            page === '...' ? (
-              <span
-                key={`ellipsis-${index}`}
-                className="w-10 h-10 flex items-center justify-center"
-              >
-                ...
-              </span>
-            ) : (
-              <button
-                key={page}
-                onClick={() => handlePageChange(page as number)}
-                className={`w-10 h-10 rounded-md transition-colors ${
-                  currentPage === page
-                    ? 'bg-orange-600 text-white'
-                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                }`}
-              >
-                {page}
-              </button>
-            )
-          )}
-        </div>
-
-        <button
-          onClick={() => handlePageChange(currentPage + 1)}
-          disabled={currentPage === totalPages}
-          className={`px-4 py-2 rounded-md transition-colors ${
-            currentPage === totalPages
-              ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-              : 'bg-orange-600 text-white hover:bg-orange-700'
-          }`}
-        >
-          Next
-        </button>
-      </div>
-    );
-  };
-
-  if (loading) {
-    return (
-      <div className="min-h-[400px] flex items-center justify-center">
-        <SquareLoader text="Loading..." />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="text-center py-12">
-        <p className="text-red-600 mb-4">Error: {error}</p>
-        <button
-          onClick={() => window.location.reload()}
-          className="bg-orange-600 text-white px-6 py-2 rounded-lg hover:bg-orange-700 transition-colors"
-        >
-          Try Again
-        </button>
-      </div>
-    );
+  let displayBlogs: Blog[];
+  if (showPagination) {
+    const safePage = Math.min(Math.max(currentPage, 1), Math.max(totalPages, 1));
+    const startIndex = (safePage - 1) * itemsPerPage;
+    displayBlogs = allBlogs.slice(startIndex, startIndex + itemsPerPage);
+  } else {
+    displayBlogs = limit ? allBlogs.slice(0, limit) : allBlogs;
   }
 
   if (displayBlogs.length === 0) {
@@ -193,8 +119,7 @@ const BlogListContent = ({
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold mb-4">Our Blogs</h2>
             <p className="text-gray-600 text-xl max-w-3xl mx-auto">
-              Stay updated with the latest ideas, inspiration, and innovations
-              from the furnishing world
+              Stay updated with the latest ideas, inspiration, and innovations from the furnishing world
             </p>
           </div>
         )}
@@ -246,22 +171,8 @@ const BlogListContent = ({
           })}
         </div>
 
-        {showPagination && <PaginationControls />}
+        {showPagination && <PaginationControls currentPage={currentPage} totalPages={totalPages} />}
       </div>
     </section>
-  );
-};
-
-export default function BlogList(props: BlogListProps) {
-  return (
-    <Suspense
-      fallback={
-        <div className="min-h-[400px] flex items-center justify-center">
-          <SquareLoader text="Loading..." />
-        </div>
-      }
-    >
-      <BlogListContent {...props} />
-    </Suspense>
   );
 }

--- a/src/components/category/category-page.tsx
+++ b/src/components/category/category-page.tsx
@@ -2,27 +2,24 @@
 'use client';
 
 import React, { useState, useEffect, useMemo } from "react";
-import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
-import SquareLoader from "../common/loader";
-import { getCategories, getProducts } from "@/lib/api";
 import { Category, Product, getFullImageUrl, getProductDisplayPrice } from "@/lib/interfaces";
 
 interface CategoryPageProps {
     slug?: string;
+    // Products (already filtered to this category) and the category itself are
+    // fetched on the cached server and passed in as props.
+    initialProducts?: Product[];
+    initialCategory?: Category | null;
 }
 
-export default function CategoryPage({ slug: propSlug }: CategoryPageProps) {
-    const params = useParams();
-    const router = useRouter();
-    
-    const slug = propSlug || (params?.slug as string);
-    const [categoryProducts, setCategoryProducts] = useState<Product[]>([]);
-    const [currentCategory, setCurrentCategory] = useState<Category | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [filterLoading, setFilterLoading] = useState(false);
+export default function CategoryPage({
+    initialProducts = [],
+    initialCategory = null,
+}: CategoryPageProps) {
+    const categoryProducts = initialProducts;
+    const currentCategory = initialCategory;
 
     const [selectedBrands, setSelectedBrands] = useState<string[]>([]);
     const [selectedPriceRanges, setSelectedPriceRanges] = useState<string[]>([]);
@@ -32,16 +29,8 @@ export default function CategoryPage({ slug: propSlug }: CategoryPageProps) {
 
     const categoryName = currentCategory?.name;
 
-    const scrollToTop = () => {
-        window.scrollTo({
-            top: 0,
-            behavior: 'smooth'
-        });
-    };
-
     // Filter products based on selected filters
     const filteredProducts = useMemo(() => {
-        setFilterLoading(true);
         let filtered = categoryProducts;
 
         // Filter by brands
@@ -72,7 +61,6 @@ export default function CategoryPage({ slug: propSlug }: CategoryPageProps) {
             });
         }
 
-        setFilterLoading(false);
         return filtered;
     }, [categoryProducts, selectedBrands, selectedPriceRanges]);
 
@@ -96,56 +84,8 @@ export default function CategoryPage({ slug: propSlug }: CategoryPageProps) {
     }, [selectedBrands, selectedPriceRanges]);
 
     useEffect(() => {
-        scrollToTop();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
     }, [currentPage]);
-
-    useEffect(() => {
-        const fetchCategoryData = async () => {
-            if (!slug || typeof slug !== 'string') {
-                return;
-            }
-
-            try {
-                setLoading(true);
-                setError(null);
-
-                // Fetch categories and products using centralized API
-                const [categoriesData, productsData] = await Promise.all([
-                    getCategories(),
-                    getProducts()
-                ]);
-
-                // Find current category
-                const normalizedSlug = slug.toLowerCase().trim();
-                const category = categoriesData?.find((cat: Category) => 
-                    cat.slug.toLowerCase().trim() === normalizedSlug
-                );
-
-                if (!category) {
-                    setError('Category not found');
-                    setLoading(false);
-                    return;
-                }
-
-                setCurrentCategory(category);
-
-                // Filter products for this category
-                const categoryProductsList = productsData?.filter(
-                    (p: Product) => p.category?.slug.toLowerCase().trim() === normalizedSlug
-                ) || [];
-
-                setCategoryProducts(categoryProductsList);
-
-            } catch (error) {
-                console.error('Error fetching category data:', error);
-                setError('Failed to load category data. Please try again.');
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        fetchCategoryData();
-    }, [slug]);
 
     const handlePageChange = (newPage: number) => {
         setCurrentPage(newPage);
@@ -261,46 +201,8 @@ export default function CategoryPage({ slug: propSlug }: CategoryPageProps) {
         );
     };
 
-    if (loading) {
-        return (
-            <div className="min-h-screen flex items-center justify-center">
-                <SquareLoader text="Loading..." />
-            </div>
-        );
-    }
-
-    if (error) {
-        return (
-            <div className="min-h-screen flex items-center justify-center">
-                <div className="text-center">
-                    <h1 className="text-2xl font-bold text-red-600 mb-4">Error</h1>
-                    <p className="text-gray-600 mb-4">{error}</p>
-                    <button
-                        onClick={() => router.push('/')}
-                        className="bg-orange-600 text-white px-6 py-2 rounded-lg hover:bg-orange-700 transition-colors"
-                    >
-                        Go Back Home
-                    </button>
-                </div>
-            </div>
-        );
-    }
-
     if (!currentCategory) {
-        return (
-            <div className="min-h-screen flex items-center justify-center">
-                <div className="text-center">
-                    <h1 className="text-2xl font-bold text-gray-800 mb-4">Category Not Found</h1>
-                    <p className="text-gray-600 mb-4">The category you're looking for doesn't exist.</p>
-                    <button
-                        onClick={() => router.push('/')}
-                        className="bg-orange-600 text-white px-6 py-2 rounded-lg hover:bg-orange-700 transition-colors"
-                    >
-                        Go Back Home
-                    </button>
-                </div>
-            </div>
-        );
+        return null;
     }
 
     return (
@@ -427,11 +329,7 @@ export default function CategoryPage({ slug: propSlug }: CategoryPageProps) {
                         )}
 
                         {/* Products */}
-                        {filterLoading ? (
-                            <div className="flex justify-center items-center h-64">
-                                <SquareLoader text="Filtering products..." />
-                            </div>
-                        ) : filteredProducts.length === 0 ? (
+                        {filteredProducts.length === 0 ? (
                             <div className="bg-white rounded-lg shadow-sm p-12 text-center">
                                 <h2 className="text-xl font-semibold text-gray-700 mb-4">No Products Found</h2>
                                 <p className="text-gray-600 mb-6">Try adjusting your filters to see more results.</p>

--- a/src/components/shop/product-section.tsx
+++ b/src/components/shop/product-section.tsx
@@ -6,7 +6,6 @@ import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import SquareLoader from "../common/loader";
 import { Suspense } from 'react';
-import { getCategories, getProducts } from "@/lib/api";
 import { Category, Product, ProductListItem, toProductListItem, formatPrice } from "@/lib/interfaces";
 
 interface ProductsSectionProps {
@@ -15,6 +14,9 @@ interface ProductsSectionProps {
     sort?: string;
     itemsPerPage?: number;
     showAll?: boolean;
+    // Data fetched on the server (cached) and passed in as props.
+    initialProducts?: Product[];
+    initialCategories?: Category[];
 }
 
 // Custom hook for debouncing
@@ -39,113 +41,69 @@ function ProductsSectionContent({
     category,
     sort,
     itemsPerPage = 12,
+    initialProducts = [],
+    initialCategories = [],
 }: ProductsSectionProps) {
     const router = useRouter();
     const searchParams = useSearchParams();
-    
-    // State
-    const [products, setProducts] = useState<ProductListItem[]>([]);
-    const [categories, setCategories] = useState<Category[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+
     const [hoveredProduct, setHoveredProduct] = useState<number | null>(null);
-    
+
     // Filter states - initialize from URL
     const [selectedCategories, setSelectedCategories] = useState<string[]>(
         category ? category.split(',') : []
     );
     const [selectedBrands, setSelectedBrands] = useState<string[]>([]);
     const [sortBy, setSortBy] = useState(sort || 'default');
-    
-    // Pagination state
-    const [totalProducts, setTotalProducts] = useState(0);
-    const [totalPages, setTotalPages] = useState(1);
+
+    // Categories come from the server (cached) via props.
+    const categories = initialCategories;
 
     // Debounce filter values to prevent too many URL updates
     const debouncedCategories = useDebounce(selectedCategories, 500);
     const debouncedBrands = useDebounce(selectedBrands, 500);
     const debouncedSort = useDebounce(sortBy, 500);
 
-    // Fetch categories on mount
-    useEffect(() => {
-        const fetchCategories = async () => {
-            try {
-                const data = await getCategories();
-                setCategories(data);
-            } catch (error) {
-                console.error('Error fetching categories:', error);
-            }
-        };
+    // Derive the visible products by filtering + sorting + paginating the
+    // server-provided data on the client (no API request here).
+    const { products, totalProducts, totalPages } = useMemo(() => {
+        let filtered = [...initialProducts];
 
-        fetchCategories();
-    }, []);
+        if (selectedCategories.length > 0) {
+            filtered = filtered.filter(
+                (p) => p.category && selectedCategories.includes(p.category.name)
+            );
+        }
 
-    // Fetch products when dependencies change
-    useEffect(() => {
-        const fetchProducts = async () => {
-            try {
-                setLoading(true);
-                setError(null);
-                
-                const allProducts = await getProducts();
-                
-                // Filter products based on selected categories and brands
-                let filtered = [...allProducts];
-                
-                if (selectedCategories.length > 0) {
-                    filtered = filtered.filter(p => 
-                        p.category && selectedCategories.includes(p.category.name)
-                    );
+        if (selectedBrands.length > 0) {
+            filtered = filtered.filter((p) =>
+                selectedBrands.includes(p.brand.toLowerCase())
+            );
+        }
+
+        if (sortBy !== 'default') {
+            filtered.sort((a, b) => {
+                const priceA = (a.retail_price || a.purchase_price || 0) as number;
+                const priceB = (b.retail_price || b.purchase_price || 0) as number;
+                switch (sortBy) {
+                    case 'price-asc': return priceA - priceB;
+                    case 'price-desc': return priceB - priceA;
+                    case 'name-asc': return a.name.localeCompare(b.name);
+                    case 'name-desc': return b.name.localeCompare(a.name);
+                    default: return 0;
                 }
-                
-                if (selectedBrands.length > 0) {
-                    filtered = filtered.filter(p => 
-                        selectedBrands.includes(p.brand.toLowerCase())
-                    );
-                }
-                
-                // Sort products
-                if (sortBy !== 'default') {
-                    filtered.sort((a, b) => {
-                        const priceA = a.retail_price || a.purchase_price || 0;
-                        const priceB = b.retail_price || b.purchase_price || 0;
-                        
-                        switch(sortBy) {
-                            case 'price-asc':
-                                return (priceA as number) - (priceB as number);
-                            case 'price-desc':
-                                return (priceB as number) - (priceA as number);
-                            case 'name-asc':
-                                return a.name.localeCompare(b.name);
-                            case 'name-desc':
-                                return b.name.localeCompare(a.name);
-                            default:
-                                return 0;
-                        }
-                    });
-                }
-                
-                setTotalProducts(filtered.length);
-                setTotalPages(Math.ceil(filtered.length / itemsPerPage));
-                
-                // Apply pagination
-                const startIndex = (page - 1) * itemsPerPage;
-                const paginatedProducts = filtered.slice(startIndex, startIndex + itemsPerPage);
-                
-                // Transform to list items
-                const productListItems = paginatedProducts.map(toProductListItem);
-                setProducts(productListItems);
+            });
+        }
 
-            } catch (error) {
-                console.error('Error fetching products:', error);
-                setError('Failed to load products. Please try again.');
-            } finally {
-                setLoading(false);
-            }
-        };
+        const total = filtered.length;
+        const pages = Math.ceil(total / itemsPerPage) || 1;
+        const startIndex = (page - 1) * itemsPerPage;
+        const paginated = filtered
+            .slice(startIndex, startIndex + itemsPerPage)
+            .map(toProductListItem);
 
-        fetchProducts();
-    }, [page, selectedCategories, selectedBrands, sortBy, itemsPerPage]);
+        return { products: paginated, totalProducts: total, totalPages: pages };
+    }, [initialProducts, selectedCategories, selectedBrands, sortBy, page, itemsPerPage]);
 
     // Update URL when debounced filters change
     useEffect(() => {
@@ -221,22 +179,6 @@ function ProductsSectionContent({
         return Array.from(uniqueBrands);
     }, []);
 
-    if (error) {
-        return (
-            <div className="min-h-[500px] flex items-center justify-center">
-                <div className="text-center">
-                    <p className="text-red-600 text-lg mb-4">{error}</p>
-                    <button
-                        onClick={() => window.location.reload()}
-                        className="bg-orange-600 text-white px-6 py-2 rounded-md hover:bg-orange-700 transition-colors"
-                    >
-                        Try Again
-                    </button>
-                </div>
-            </div>
-        );
-    }
-
     return (
         <div className="py-16 bg-white">
             <div className="container mx-auto px-4 sm:px-6 lg:px-8">
@@ -251,7 +193,7 @@ function ProductsSectionContent({
 
                 <div className="flex flex-col lg:flex-row gap-8">
                     {/* Filters Sidebar */}
-                    {!loading && products.length > 0 && (
+                    {products.length > 0 && (
                         <div className="w-full lg:w-64 flex-shrink-0">
                             <div className="bg-gray-50 p-6 rounded-lg sticky top-24">
                                 <div className="flex justify-between items-center mb-6">
@@ -312,43 +254,35 @@ function ProductsSectionContent({
                             </div>
                         </div>
 
-                        {loading ? (
-                            <div className="min-h-[500px] flex items-center justify-center">
-                                <SquareLoader text="Loading..." />
+                        {products.length === 0 ? (
+                            <div className="text-center py-12">
+                                <p className="text-gray-500 text-lg mb-4">No products found.</p>
+                                <Link
+                                    href="/shop"
+                                    className="text-orange-600 hover:text-orange-700 font-medium"
+                                >
+                                    Browse all products
+                                </Link>
                             </div>
                         ) : (
                             <>
-                                {products.length === 0 ? (
-                                    <div className="text-center py-12">
-                                        <p className="text-gray-500 text-lg mb-4">No products found.</p>
-                                        <Link
-                                            href="/shop"
-                                            className="text-orange-600 hover:text-orange-700 font-medium"
-                                        >
-                                            Browse all products
-                                        </Link>
-                                    </div>
-                                ) : (
-                                    <>
-                                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-8 mb-8">
-                                            {products.map((product) => (
-                                                <ProductCard
-                                                    key={product.id}
-                                                    product={product}
-                                                    isHovered={hoveredProduct === product.id}
-                                                    onHover={setHoveredProduct}
-                                                />
-                                            ))}
-                                        </div>
+                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-8 mb-8">
+                                    {products.map((product) => (
+                                        <ProductCard
+                                            key={product.id}
+                                            product={product}
+                                            isHovered={hoveredProduct === product.id}
+                                            onHover={setHoveredProduct}
+                                        />
+                                    ))}
+                                </div>
 
-                                        {totalPages > 1 && (
-                                            <Pagination
-                                                currentPage={page}
-                                                totalPages={totalPages}
-                                                onPageChange={handlePageChange}
-                                            />
-                                        )}
-                                    </>
+                                {totalPages > 1 && (
+                                    <Pagination
+                                        currentPage={page}
+                                        totalPages={totalPages}
+                                        onPageChange={handlePageChange}
+                                    />
                                 )}
                             </>
                         )}

--- a/src/components/shop/single-product.tsx
+++ b/src/components/shop/single-product.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { Facebook, Twitter, Instagram, Phone, MapPin, Check } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
@@ -10,18 +10,17 @@ import {
     AccordionTrigger,
     AccordionContent,
 } from "@/components/ui/accordion";
-import { getProducts } from "@/lib/api";
 import { Product, getFullImageUrl, formatPrice } from "@/lib/interfaces";
 
 interface SingleProductProps {
     productData: Product;
+    // Related products are computed on the cached server and passed in.
+    relatedProducts?: Product[];
 }
 
-export default function SingleProduct({ productData }: SingleProductProps) {
+export default function SingleProduct({ productData, relatedProducts = [] }: SingleProductProps) {
     const [activeTab, setActiveTab] = useState("description");
     const [selectedImage, setSelectedImage] = useState(0);
-    const [relatedProducts, setRelatedProducts] = useState<Product[]>([]);
-    const [loadingRelated, setLoadingRelated] = useState(true);
 
     // Get category name safely
     const categoryName = productData.category?.name || 'Uncategorized';
@@ -31,45 +30,6 @@ export default function SingleProduct({ productData }: SingleProductProps) {
     const galleryImages = useMemo(() => {
         return (productData.images.gallery || []).filter(img => img);
     }, [productData.images.gallery]);
-
-    // Fetch related products
-    useEffect(() => {
-        const abortController = new AbortController();
-
-        const fetchRelatedProducts = async () => {
-            try {
-                setLoadingRelated(true);
-                const allProducts = await getProducts();
-                
-                // Filter products from same category, excluding current product
-                let related = allProducts
-                    .filter((p: Product)  => 
-                        p.category?.slug === categorySlug && 
-                        p.id !== productData.id
-                    )
-                    .slice(0, 4);
-
-                // If no products in same category, get any other products
-                if (related.length === 0) {
-                    related = allProducts
-                        .filter((p: Product)  => p.id !== productData.id)
-                        .slice(0, 4);
-                }
-
-                setRelatedProducts(related);
-            } catch (error) {
-                if (error instanceof Error && error.name !== 'AbortError') {
-                    console.error('Error fetching related products:', error);
-                }
-            } finally {
-                setLoadingRelated(false);
-            }
-        };
-
-        fetchRelatedProducts();
-
-        return () => abortController.abort();
-    }, [categorySlug, productData.id]);
 
     // Static FAQs as fallback
     const staticFaqs = useMemo(() => [
@@ -448,14 +408,7 @@ export default function SingleProduct({ productData }: SingleProductProps) {
                             Related Products
                         </h2>
 
-                        {loadingRelated ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-                                {[...Array(4)].map((_, index) => (
-                                    <div key={index} className="bg-gray-200 animate-pulse rounded-2xl h-80"></div>
-                                ))}
-                            </div>
-                        ) : (
-                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
                                 {relatedProducts.map((product) => (
                                     <Link
                                         key={product.id}
@@ -500,7 +453,6 @@ export default function SingleProduct({ productData }: SingleProductProps) {
                                     </Link>
                                 ))}
                             </div>
-                        )}
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Summary
Front-end performance optimizations: faster LCP, smaller browser payloads, less client-side JavaScript, and a cache-first architecture that keeps the site fast even when the CMS is slow or down.

## 1. Hero / LCP image -> next/image (hero-section.tsx)
- Was a CSS background-image bypassing Next's image pipeline (sofa.jpg was ~4 MB).
- Now next/image with fill + priority + sizes -> WebP/AVIF, resized, preloaded.

## 2. Less client JS
- Below-the-fold homepage sections lazy-loaded with next/dynamic (SSR kept on).
- ReviewSchema is a server component (static JSON-LD, zero client JS).

## 3. API fetching moved to cached server components
- Blog post page, blog list, shop, category and product pages fetch on the server (centralized lib/api.ts); client components receive data as props and keep only interactive UI (filters, sort).
- Net effect: the browser no longer downloads the multi-MB product/blog JSON.

## 4. Static (SSG + ISR) rendering for all content pages
- Blog pagination moved from ?page=N (dynamic on every request) to static /blog/page/N routes via generateStaticParams; /blog is static ISR again; old ?page URLs 301-redirect.
- generateStaticParams added to /blog/[slug], /shop/[...slug] and /category/[...slug]: all posts, products and categories are prerendered and served from cache. The CMS is only contacted on revalidation (30 min), never on a user request -> fast TTFB and resilient to CMS outages (the CMS dropped repeatedly during testing; cached pages kept serving).
- Local timing: /blog 0.15s, /blog/page/2 0.04s warm (previously ~3.7s or hanging when the CMS stalled).

## 5. Browser-cacheable API responses
- New same-origin proxy routes /api/products and /api/categories (revalidate 30m/1h) served with Cache-Control: public, max-age=3600, stale-while-revalidate=86400.
- Client-side fetches (navbar, footer, search autocomplete, breadcrumbs) now hit these instead of the CMS directly: cached by browser + CDN, and deduped in-session.

## 6. Loading feedback for pagination
- Route-level loading.tsx for /blog and /shop.
- Pagination links show an inline pending spinner via useLinkStatus.

## 7. Homepage image fixes
- Certificate logos <Image> had no width/height (invalid usage) -> fixed.
- Promo banner fill images had no sizes -> browsers downloaded ~2x larger files; fixed with proper sizes.

## 8. Blog content typography
- Replaced the minimal prose CSS (h3 was body-text size) with a full set: h2/h3/h4 scale, styled lists with markers, bordered striped tables (mobile-scrollable, orange header), blockquotes, links, images.

## Verification
- next build passes; blog posts, products and categories prerender as SSG (route map shows them as ● SSG).
- Cache headers on /api/products and /api/categories verified locally.

## Out of scope (follow-ups)
- CMS-side pagination/field selection: /api/blogs/all-blogs is ~2.8 MB and /api/products ~2.4 MB, both above Next's 2 MB data-cache limit, so server revalidations re-download them in full.
- CMS reliability: cms.furnishings.daikimedia.com showed repeated TLS failures/outages during testing; worth raising with hosting.
- Dead component src/components/home/category-tabs.tsx (only framer-motion user) can be removed.