### PR TITLE
perf: static pagination + cached API routes, image fixes, blog typography

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,18 @@ const nextConfig: NextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * 30, // 30 days
   },
 
+  async redirects() {
+    return [
+      // Old query-string pagination -> static path-based pagination
+      {
+        source: "/blog",
+        has: [{ type: "query", key: "page", value: "(?<p>[2-9]|\\d{2,})" }],
+        destination: "/blog/page/:p",
+        permanent: true,
+      },
+    ];
+  },
+
   async headers() {
     return [
       {

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,9 @@
+import { getCategories } from "@/lib/api";
+
+// Same-origin proxy for the CMS categories endpoint (see api/products/route.ts).
+export const revalidate = 3600;
+
+export async function GET() {
+  const categories = await getCategories();
+  return Response.json({ success: true, data: categories });
+}

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,12 @@
+import { getProducts } from "@/lib/api";
+
+// Same-origin proxy for the CMS products endpoint. Client components fetch
+// this instead of the CMS directly so responses are served with the
+// Cache-Control headers from next.config.ts (browser + CDN cacheable) and the
+// CMS is only hit from the shared server data cache.
+export const revalidate = 1800;
+
+export async function GET() {
+  const products = await getProducts();
+  return Response.json({ success: true, data: products });
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,11 +1,23 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import SingleBlogContent from "@/components/blog/single-blog-content";
-import { getBlogBySlug } from "@/lib/api";
+import { getBlogBySlug, getBlogs } from "@/lib/api";
 
 type Props = {
   params: Promise<{ slug: string }>;
 };
+
+// Prerender every blog post (SSG + ISR): posts are served from the static
+// cache instead of rendering on demand, so they stay fast and available even
+// when the CMS is slow or down. New posts not in the build are rendered on
+// first request (dynamicParams default) and cached from then on.
+export async function generateStaticParams() {
+  const response = await getBlogs();
+  const blogs = response.success && Array.isArray(response.data) ? response.data : [];
+  return blogs
+    .filter((blog: { slug?: string }) => typeof blog.slug === "string" && blog.slug.length > 0)
+    .map((blog: { slug: string }) => ({ slug: blog.slug }));
+}
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;

--- a/src/app/blog/loading.tsx
+++ b/src/app/blog/loading.tsx
@@ -1,0 +1,11 @@
+import SquareLoader from "@/components/common/loader";
+
+// Route-level loading UI: shown instantly while the server renders the next
+// page of blogs (e.g. after clicking a pagination link).
+export default function Loading() {
+    return (
+        <div className="min-h-[60vh] flex items-center justify-center">
+            <SquareLoader text="Loading..." />
+        </div>
+    );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -12,17 +12,10 @@ export const metadata: Metadata = {
     },
 };
 
-interface BlogPageProps {
-  searchParams?: Promise<{
-    page?: string;
-  }>;
-}
-
-export default async function BlogPage({ searchParams }: BlogPageProps) {
-
-  const params = await searchParams;
-  const currentPage = Number(params?.page) || 1;
-
+// Static ISR page (no searchParams): pagination lives at /blog/page/[n], so
+// every blog page is served from the static cache and the CMS is only hit on
+// revalidation — never on a user request.
+export default function BlogPage() {
   return (
     <main>
       <PageHeader title="Flooring & Home Décor Blog in Malaysia" />
@@ -31,7 +24,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
         <BlogList
           showPagination={true}
           itemsPerPage={9}
-          currentPage={currentPage}
+          currentPage={1}
         />
       </Suspense>
 

--- a/src/app/blog/page/[pageNumber]/page.tsx
+++ b/src/app/blog/page/[pageNumber]/page.tsx
@@ -1,0 +1,67 @@
+import { notFound, redirect } from "next/navigation";
+import { Suspense } from "react";
+import type { Metadata } from "next";
+import PageHeader from "@/components/common/header";
+import BlogList from "@/components/blogs/blog-section";
+import ProductsLoading from "@/components/shop/products-loading";
+import { getBlogs } from "@/lib/api";
+
+// Path-based pagination (/blog/page/2, /blog/page/3, ...) so every page is a
+// static ISR page served from cache. Query-string pagination would force the
+// route to render dynamically on every request.
+const ITEMS_PER_PAGE = 9;
+
+type Props = {
+  params: Promise<{ pageNumber: string }>;
+};
+
+export async function generateStaticParams() {
+  const response = await getBlogs();
+  const total = response.success && Array.isArray(response.data) ? response.data.length : 0;
+  const totalPages = Math.max(Math.ceil(total / ITEMS_PER_PAGE), 1);
+
+  // Page 1 lives at /blog, so prebuild pages 2..N.
+  return Array.from({ length: Math.max(totalPages - 1, 0) }, (_, i) => ({
+    pageNumber: String(i + 2),
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { pageNumber } = await params;
+  return {
+    title: `Flooring & Home Décor Blog Malaysia | Page ${pageNumber} | Furnishing`,
+    description:
+      "Read flooring and home décor tips for Malaysian homes and offices on the Furnishing blog. Discover vinyl, SPC, laminate and carpet tile ideas, maintenance guides and renovation inspiration.",
+    alternates: {
+      canonical: `https://www.furnishings.com.my/blog/page/${pageNumber}`,
+    },
+  };
+}
+
+export default async function BlogPaginatedPage({ params }: Props) {
+  const { pageNumber } = await params;
+  const currentPage = Number(pageNumber);
+
+  if (!Number.isInteger(currentPage) || currentPage < 1) {
+    notFound();
+  }
+  if (currentPage === 1) {
+    redirect("/blog");
+  }
+
+  return (
+    <main>
+      <PageHeader title="Flooring & Home Décor Blog in Malaysia" />
+
+      <Suspense fallback={<ProductsLoading />}>
+        <BlogList
+          showPagination={true}
+          itemsPerPage={ITEMS_PER_PAGE}
+          currentPage={currentPage}
+        />
+      </Suspense>
+    </main>
+  );
+}
+
+export const revalidate = 1800;

--- a/src/app/category/[...slug]/page.tsx
+++ b/src/app/category/[...slug]/page.tsx
@@ -11,6 +11,18 @@ type Props = {
   params: Promise<{ slug: string[] }>;
 };
 
+// Prerender all category pages (SSG + ISR) — there are only a handful and
+// they then serve from the static cache regardless of CMS availability.
+export async function generateStaticParams() {
+  const categories: Category[] = await getCategories();
+  if (!Array.isArray(categories)) return [];
+  return categories
+    .filter((c) => typeof c.slug === "string" && c.slug.length > 0)
+    .map((c) => ({ slug: [c.slug] }));
+}
+
+export const revalidate = 1800;
+
 export default async function CategoryPageRoute({ params }: Props) {
   const { slug } = await params;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,21 +127,127 @@ html {
   scroll-behavior: smooth;
 }
 
-/* Blog post prose heading styles */
+/* Blog post (CMS HTML) typography: consistent heading scale, styled lists,
+   tables and other elements the CMS editor can produce. */
 .prose h2 {
-  font-size: 2.25rem;
-  font-weight: 800;
+  font-size: 1.875rem;
+  font-weight: 700;
   color: #111827;
-  margin-top: 3rem;
+  margin-top: 2.5rem;
   margin-bottom: 1rem;
-  line-height: 1.2;
+  line-height: 1.25;
 }
 
 .prose h3 {
-  font-size: 1rem;
+  font-size: 1.5rem;
   font-weight: 700;
+  color: #111827;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.3;
+}
+
+.prose h4 {
+  font-size: 1.25rem;
+  font-weight: 600;
   color: #111827;
   margin-top: 1.5rem;
   margin-bottom: 0.5rem;
-  line-height: 1.5;
+  line-height: 1.4;
+}
+
+.prose p {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  line-height: 1.75;
+}
+
+.prose ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+.prose ol {
+  list-style-type: decimal;
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+.prose li {
+  margin: 0.375rem 0;
+  line-height: 1.7;
+}
+
+.prose li::marker {
+  color: #ea580c;
+}
+
+.prose a {
+  color: #ea580c;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.prose a:hover {
+  color: #c2410c;
+}
+
+.prose blockquote {
+  border-left: 4px solid #ea580c;
+  background: #fff7ed;
+  padding: 0.75rem 1.25rem;
+  margin: 1.5rem 0;
+  border-radius: 0 0.5rem 0.5rem 0;
+  font-style: italic;
+  color: #374151;
+}
+
+.prose img {
+  border-radius: 0.5rem;
+  margin: 1.5rem auto;
+  max-width: 100%;
+  height: auto;
+}
+
+/* Tables: wrap-friendly, bordered, readable on mobile */
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+  display: block;
+  overflow-x: auto;
+}
+
+.prose thead {
+  background-color: #ea580c;
+}
+
+.prose thead th {
+  color: #ffffff;
+}
+
+.prose th,
+.prose td {
+  border: 1px solid #e5e7eb;
+  padding: 0.625rem 1rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.prose th {
+  background-color: #ea580c;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.prose tbody tr:nth-child(even) {
+  background-color: #f9fafb;
+}
+
+.prose hr {
+  border: 0;
+  border-top: 1px solid #e5e7eb;
+  margin: 2rem 0;
 }

--- a/src/app/shop/[...slug]/page.tsx
+++ b/src/app/shop/[...slug]/page.tsx
@@ -11,6 +11,20 @@ type Params = {
   slug: string[];
 };
 
+// Prerender every product page (SSG + ISR) at its canonical
+// /shop/{category}/{product} path so product pages are served from the static
+// cache — fast TTFB and resilient to CMS slowness/outages. Products added
+// after the build render on first request and are cached from then on.
+export async function generateStaticParams() {
+  const products = await getProducts();
+  if (!Array.isArray(products)) return [];
+  return products
+    .filter((p: Product) => typeof p.slug === "string" && p.slug.length > 0)
+    .map((p: Product) => ({
+      slug: [p.category?.slug || "uncategorized", p.slug],
+    }));
+}
+
 export default async function ProductPage({
   params,
 }: {

--- a/src/app/shop/loading.tsx
+++ b/src/app/shop/loading.tsx
@@ -1,0 +1,6 @@
+import ProductsLoading from "@/components/shop/products-loading";
+
+// Route-level loading UI for /shop navigations (pagination, filters).
+export default function Loading() {
+    return <ProductsLoading />;
+}

--- a/src/components/blogs/blog-section.tsx
+++ b/src/components/blogs/blog-section.tsx
@@ -3,6 +3,7 @@
 // (?page=N) which the statically-rendered route serves from cache.
 import Image from 'next/image';
 import Link from 'next/link';
+import PaginationLink from '@/components/common/pagination-link';
 import { getBlogs } from '@/lib/api';
 import { Blog, getBlogImageUrl } from '@/lib/interfaces';
 
@@ -27,6 +28,9 @@ function getVisiblePages(currentPage: number, totalPages: number): (number | '..
   return [1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPages];
 }
 
+// Page 1 lives at /blog; pages 2+ live at /blog/page/N (static ISR routes).
+const pageHref = (page: number) => (page === 1 ? '/blog' : `/blog/page/${page}`);
+
 function PaginationControls({
   currentPage,
   totalPages,
@@ -44,9 +48,9 @@ function PaginationControls({
       {currentPage === 1 ? (
         <span className={`${baseBtn} bg-gray-100 text-gray-400 cursor-not-allowed`}>Previous</span>
       ) : (
-        <Link href={`?page=${currentPage - 1}`} className={`${baseBtn} bg-orange-600 text-white hover:bg-orange-700`}>
+        <PaginationLink href={pageHref(currentPage - 1)} className={`${baseBtn} bg-orange-600 text-white hover:bg-orange-700`}>
           Previous
-        </Link>
+        </PaginationLink>
       )}
 
       <div className="flex space-x-2">
@@ -56,9 +60,9 @@ function PaginationControls({
               ...
             </span>
           ) : (
-            <Link
+            <PaginationLink
               key={page}
-              href={`?page=${page}`}
+              href={pageHref(page)}
               className={`w-10 h-10 flex items-center justify-center rounded-md transition-colors ${
                 currentPage === page
                   ? 'bg-orange-600 text-white'
@@ -66,7 +70,7 @@ function PaginationControls({
               }`}
             >
               {page}
-            </Link>
+            </PaginationLink>
           )
         )}
       </div>
@@ -74,9 +78,9 @@ function PaginationControls({
       {currentPage === totalPages ? (
         <span className={`${baseBtn} bg-gray-100 text-gray-400 cursor-not-allowed`}>Next</span>
       ) : (
-        <Link href={`?page=${currentPage + 1}`} className={`${baseBtn} bg-orange-600 text-white hover:bg-orange-700`}>
+        <PaginationLink href={pageHref(currentPage + 1)} className={`${baseBtn} bg-orange-600 text-white hover:bg-orange-700`}>
           Next
-        </Link>
+        </PaginationLink>
       )}
     </div>
   );

--- a/src/components/common/pagination-link.tsx
+++ b/src/components/common/pagination-link.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Link, { useLinkStatus } from 'next/link';
+
+// Shows a small spinner inside the link while the next page is loading, so
+// users get instant feedback when they click a pagination link.
+function PendingSpinner() {
+    const { pending } = useLinkStatus();
+    if (!pending) return null;
+    return (
+        <span
+            aria-hidden
+            className="ml-2 inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent align-middle"
+        />
+    );
+}
+
+export default function PaginationLink({
+    href,
+    className,
+    children,
+}: {
+    href: string;
+    className?: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <Link href={href} scroll={true} className={className}>
+            {children}
+            <PendingSpinner />
+        </Link>
+    );
+}

--- a/src/components/home/Certificate-section.tsx
+++ b/src/components/home/Certificate-section.tsx
@@ -145,7 +145,9 @@ const CertificateCarousel = () => {
                                 <Image
                                     src={cert.logo}
                                     alt={cert.name}
-                                    className="h-48 w-auto max-w-[140px] object-contain filter hover:brightness-110 transition-all duration-300"
+                                    width={140}
+                                    height={140}
+                                    className="h-auto w-auto max-w-[140px] max-h-[140px] object-contain filter hover:brightness-110 transition-all duration-300"
                                     style={{
                                         background: 'transparent',
                                         objectFit: 'contain'

--- a/src/components/home/sales-card.tsx
+++ b/src/components/home/sales-card.tsx
@@ -13,6 +13,7 @@ export default function FurniturePromoBanner() {
                         src="/banner1.avif"
                         alt="Sofa"
                         fill
+                        sizes="(max-width: 768px) 100vw, 50vw"
                         className="object-cover object-left md:object-center transition-transform duration-500 group-hover:scale-110"
                     />
 
@@ -38,6 +39,7 @@ export default function FurniturePromoBanner() {
                         src="/banner2.jpg"
                         alt="Chair"
                         fill
+                        sizes="(max-width: 768px) 100vw, 50vw"
                         className="object-cover object-right md:object-center transition-transform duration-500 group-hover:scale-110"
                     />
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -49,11 +49,17 @@ async function fetchWithRetry(url: string, options: RequestInit = {}, retries = 
 }
 
 
+// In the browser we fetch from our own /api proxy routes instead of the CMS:
+// same-origin, served with the Cache-Control headers from next.config.ts, so
+// repeat page views hit the browser/CDN cache instead of re-downloading the
+// full payload from the CMS on every visit.
 const fetchProducts = async () => {
   try {
-    const res = await fetchWithRetry(`${API_BASE}/products`, {
-      next: { revalidate: 1800 },
-    });
+    const isBrowser = typeof window !== "undefined";
+    const res = await fetchWithRetry(
+      isBrowser ? "/api/products" : `${API_BASE}/products`,
+      isBrowser ? {} : { next: { revalidate: 1800 } }
+    );
 
     if (!res) return [];
 
@@ -113,11 +119,13 @@ export const getProductBySlug = cache(async (slug: string) => {
 });
 
 
-export const getCategories = cache(async () => {
+const fetchCategories = async () => {
   try {
-    const res = await fetchWithRetry(`${API_BASE}/categories`, {
-      next: { revalidate: 3600 },
-    });
+    const isBrowser = typeof window !== "undefined";
+    const res = await fetchWithRetry(
+      isBrowser ? "/api/categories" : `${API_BASE}/categories`,
+      isBrowser ? {} : { next: { revalidate: 3600 } }
+    );
 
     if (!res) return [];
 
@@ -127,6 +135,23 @@ export const getCategories = cache(async () => {
     console.error("Failed to fetch categories:", error);
     return [];
   }
+};
+
+// Same browser-side memoization as products: navbar + footer both call
+// getCategories() on every page, so without this the request fires repeatedly.
+let clientCategoriesPromise: ReturnType<typeof fetchCategories> | null = null;
+
+export const getCategories = cache(async () => {
+  if (typeof window !== "undefined") {
+    if (!clientCategoriesPromise) {
+      clientCategoriesPromise = fetchCategories().catch((error) => {
+        clientCategoriesPromise = null; // allow retry on failure
+        throw error;
+      });
+    }
+    return clientCategoriesPromise;
+  }
+  return fetchCategories();
 });
 
 


### PR DESCRIPTION
## Summary
Follow-up to #60: cache-first rendering for all content pages, browser-cacheable API responses, pagination loading feedback, homepage image fixes and blog typography.

## 1. Static (SSG + ISR) rendering for all content pages
- Blog pagination moved from ?page=N (rendered dynamically on every request) to static /blog/page/N routes via generateStaticParams; /blog is static ISR again; old ?page URLs 301-redirect.
- generateStaticParams added to /blog/[slug], /shop/[...slug] and /category/[...slug]: posts, products and categories are prerendered and served from cache. The CMS is only contacted on revalidation (30 min), never on a user request -> fast TTFB and resilient to CMS outages (the CMS dropped repeatedly during testing; cached pages kept serving).
- Local timing: /blog 0.15s, /blog/page/2 0.04s warm (previously ~3.7s, or hanging when the CMS stalled).

## 2. Browser-cacheable API responses
- New same-origin proxy routes /api/products and /api/categories (revalidate 30m/1h) served with Cache-Control: public, max-age=3600, stale-while-revalidate=86400.
- Client-side fetches (navbar, footer, search autocomplete, breadcrumbs) now hit these instead of the CMS directly: cached by browser + CDN, deduped in-session, and the CMS is no longer exposed to per-visitor traffic.

## 3. Loading feedback for pagination
- Route-level loading.tsx for /blog and /shop.
- Pagination links show an inline pending spinner via useLinkStatus.

## 4. Homepage image fixes
- Certificate logos <Image> had no width/height (invalid usage) -> fixed.
- Promo banner fill images had no sizes -> browsers downloaded ~2x larger files; fixed with proper sizes.

## 5. Blog content typography
- Replaced the minimal prose CSS (h3 was body-text size) with a full set: h2/h3/h4 scale, styled lists with markers, bordered striped tables (mobile-scrollable, orange header), blockquotes, links, images.

## Verification
- next build passes; blog pages, posts, products and categories prerender as SSG (route map shows ●).
- Cache headers on /api/products and /api/categories verified locally.

## Follow-ups (CMS side)
- /api/blogs/all-blogs is ~2.8 MB and /api/products ~2.4 MB, both above Next's 2 MB data-cache limit; CMS pagination/field selection is the remaining big win.
- cms.furnishings.daikimedia.com had repeated TLS failures/outages during testing; worth raising with hosting.