### PR TITLE
fix: homepage image issues, blog typography, route loading states

### DIFF
--- a/src/app/blog/loading.tsx
+++ b/src/app/blog/loading.tsx
@@ -1,0 +1,11 @@
+import SquareLoader from "@/components/common/loader";
+
+// Route-level loading UI: shown instantly while the server renders the next
+// page of blogs (e.g. after clicking a pagination link).
+export default function Loading() {
+    return (
+        <div className="min-h-[60vh] flex items-center justify-center">
+            <SquareLoader text="Loading..." />
+        </div>
+    );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,21 +127,127 @@ html {
   scroll-behavior: smooth;
 }
 
-/* Blog post prose heading styles */
+/* Blog post (CMS HTML) typography: consistent heading scale, styled lists,
+   tables and other elements the CMS editor can produce. */
 .prose h2 {
-  font-size: 2.25rem;
-  font-weight: 800;
+  font-size: 1.875rem;
+  font-weight: 700;
   color: #111827;
-  margin-top: 3rem;
+  margin-top: 2.5rem;
   margin-bottom: 1rem;
-  line-height: 1.2;
+  line-height: 1.25;
 }
 
 .prose h3 {
-  font-size: 1rem;
+  font-size: 1.5rem;
   font-weight: 700;
+  color: #111827;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.3;
+}
+
+.prose h4 {
+  font-size: 1.25rem;
+  font-weight: 600;
   color: #111827;
   margin-top: 1.5rem;
   margin-bottom: 0.5rem;
-  line-height: 1.5;
+  line-height: 1.4;
+}
+
+.prose p {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  line-height: 1.75;
+}
+
+.prose ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+.prose ol {
+  list-style-type: decimal;
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+.prose li {
+  margin: 0.375rem 0;
+  line-height: 1.7;
+}
+
+.prose li::marker {
+  color: #ea580c;
+}
+
+.prose a {
+  color: #ea580c;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.prose a:hover {
+  color: #c2410c;
+}
+
+.prose blockquote {
+  border-left: 4px solid #ea580c;
+  background: #fff7ed;
+  padding: 0.75rem 1.25rem;
+  margin: 1.5rem 0;
+  border-radius: 0 0.5rem 0.5rem 0;
+  font-style: italic;
+  color: #374151;
+}
+
+.prose img {
+  border-radius: 0.5rem;
+  margin: 1.5rem auto;
+  max-width: 100%;
+  height: auto;
+}
+
+/* Tables: wrap-friendly, bordered, readable on mobile */
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+  display: block;
+  overflow-x: auto;
+}
+
+.prose thead {
+  background-color: #ea580c;
+}
+
+.prose thead th {
+  color: #ffffff;
+}
+
+.prose th,
+.prose td {
+  border: 1px solid #e5e7eb;
+  padding: 0.625rem 1rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.prose th {
+  background-color: #ea580c;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.prose tbody tr:nth-child(even) {
+  background-color: #f9fafb;
+}
+
+.prose hr {
+  border: 0;
+  border-top: 1px solid #e5e7eb;
+  margin: 2rem 0;
 }

--- a/src/app/shop/loading.tsx
+++ b/src/app/shop/loading.tsx
@@ -1,0 +1,6 @@
+import ProductsLoading from "@/components/shop/products-loading";
+
+// Route-level loading UI for /shop navigations (pagination, filters).
+export default function Loading() {
+    return <ProductsLoading />;
+}

--- a/src/components/home/Certificate-section.tsx
+++ b/src/components/home/Certificate-section.tsx
@@ -145,7 +145,9 @@ const CertificateCarousel = () => {
                                 <Image
                                     src={cert.logo}
                                     alt={cert.name}
-                                    className="h-48 w-auto max-w-[140px] object-contain filter hover:brightness-110 transition-all duration-300"
+                                    width={140}
+                                    height={140}
+                                    className="h-auto w-auto max-w-[140px] max-h-[140px] object-contain filter hover:brightness-110 transition-all duration-300"
                                     style={{
                                         background: 'transparent',
                                         objectFit: 'contain'

--- a/src/components/home/sales-card.tsx
+++ b/src/components/home/sales-card.tsx
@@ -13,6 +13,7 @@ export default function FurniturePromoBanner() {
                         src="/banner1.avif"
                         alt="Sofa"
                         fill
+                        sizes="(max-width: 768px) 100vw, 50vw"
                         className="object-cover object-left md:object-center transition-transform duration-500 group-hover:scale-110"
                     />
 
@@ -38,6 +39,7 @@ export default function FurniturePromoBanner() {
                         src="/banner2.jpg"
                         alt="Chair"
                         fill
+                        sizes="(max-width: 768px) 100vw, 50vw"
                         className="object-cover object-right md:object-center transition-transform duration-500 group-hover:scale-110"
                     />
 


### PR DESCRIPTION
## Summary
UI and content fixes: broken/oversized homepage images, missing blog typography, and instant loading feedback on /blog and /shop.

## 1. Homepage image fixes
- Certificate logos <Image> was missing the required width/height props (invalid next/image usage that renders broken and logs errors) -> fixed with proper dimensions.
- Both promo banner fill images had no sizes prop, so browsers downloaded ~2x larger files than the rendered size -> added sizes="(max-width: 768px) 100vw, 50vw".

## 2. Blog content typography
The CMS blog HTML was rendering with almost no styling (only h2/h3 rules existed, and h3 was body-text size). Added a full typography set for .prose content:
- Proper heading scale (h2/h3/h4)
- Styled bullet/numbered lists with brand-colored markers
- Bordered, striped tables with orange header row, horizontally scrollable on mobile
- Blockquotes, links, images, hr

## 3. Route loading states
- Added route-level loading.tsx for /blog and /shop so navigation shows an instant loading screen instead of a frozen page while the server renders.

## Verification
- next build passes (all routes compile and generate).