### PR TITLE
fix: loader covered the whole site with a white screen

### DIFF
--- a/src/components/common/loader.tsx
+++ b/src/components/common/loader.tsx
@@ -7,8 +7,13 @@ interface SquareLoaderProps {
 }
 
 const SquareLoader: React.FC<SquareLoaderProps> = ({ text = "Loading..." }) => {
+  // In-flow loader: must NOT be a fixed full-viewport overlay. As a fixed
+  // overlay (fixed inset-0 z-[9999]) any section waiting on data covered the
+  // whole site with a white screen — users saw only "Loading..." until the
+  // CMS responded (or timed out after ~30s) even though the rest of the page
+  // was already rendered underneath.
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-white z-[9999]">
+    <div className="flex w-full items-center justify-center py-16">
       <div className="text-center">
         <div className="relative w-[116px] h-[86px] mx-auto mb-4">
           <div className="square animate-square1" />


### PR DESCRIPTION
## Problem
The live site shows only "Loading..." on a blank white screen (screenshot reported today). The server HTML is actually fine - the page is fully rendered underneath.

## Root cause
SquareLoader (components/common/loader.tsx) is a fixed full-viewport overlay:

    <div className="fixed inset-0 ... bg-white z-[9999]">

Any section that shows it while waiting for data covers the ENTIRE site. On the homepage, the "Our Floor Collections" section fetches categories from the CMS in the browser; while that request is pending (and the CMS has been slow/unreachable several times today - TLS failures and 508s), visitors see nothing but a white screen with "Loading...", even though navbar, hero and all other sections are already rendered behind the overlay. Worst case is ~30s (3 retries x 10s timeout) or indefinitely while the CMS flaps.

## Fix
One change: the loader now renders in-flow inside its own section instead of covering the viewport. The page stays visible and usable while any section loads.

## Verification (local production build)
- next build passes
- Homepage HTML contains the in-flow loader, no fixed overlay from the loader
- Browser check: navbar + hero render immediately, collections section loads its cards, zero console errors

## Note
The pending PR with static rendering + cached /api proxy routes (branch perf/static-pagination-cached-api) removes most of these browser-to-CMS fetches entirely, which prevents this class of issue at the source. Recommend merging that as well.